### PR TITLE
Implement Minh's FPA update

### DIFF
--- a/dispersion/MatRocketV2.m
+++ b/dispersion/MatRocketV2.m
@@ -95,12 +95,33 @@ for i=1:m
             rocketProp.wetMass = RProp{2}(i); %[kg] mass of structure+propellant
         case 'radius'
             rocketProp.radius = RProp{2}(i); %[in]radius of body
+        case 'numfins'
+            rocketProp.numfins = RProp{2}(i); %number of fins on the rocket
+        case 'rootchord'
+            rocketProp.rootchord = RProp{2}(i); %[m] fin root chord
+        case 'tipchord'
+            rocketProp.tipchord = RProp{2}(i); %[m] fin tip chord
+        case 'finheight'
+            rocketProp.finheight = RProp{2}(i); %[m] fin height
+        case 'C_G'
+            rocketProp.C_G = RProp{2}(i); %[m]Center of mass (From OpenRocket)
+        case 'C_P'
+            rocketProp.C_P = RProp{2}(i); %[m] Center of pressure (From OpenRocket)
+        case 'rocketlength'
+            rocketProp.rocketlength = RProp{2}(i); %[m] Rocket length
+        case 'launcherlength'
+            rocketProp.launcherlength = RProp{2}(i); %[m] Launcher length
         case 'rho'
             simuProp.rho = RProp{2}(i); %[kg/m^3] air density
+        case 'meanCantAngle'
+            rocketProp.meanCantAngle = RProp{2}(i); %mean cant angle [rad]; rocket being built to 0 cant but assuming worst case scenario of .5 degrees
+        case 'liftCoefficientSlope'
+            rocketProp.liftCoefficientSlope = RProp{2}(i);
         case 'drag'
             simuProp.drag = RProp{2}(i); %drag coefficient
         case 'gravity'
             simuProp.gravity = RProp{2}(i); %[m/s^2] gravitational acceleration
+        
         
         % --Motor Properties--
         case 'thrust'
@@ -111,6 +132,8 @@ for i=1:m
             rocketProp.iTotal = RProp{2}(i); %[N-s] total impulse
         case 'burn'
             rocketProp.burnTime = RProp{2}(i); %[s]An option to override the burn time
+        case 'thrustma'
+            rocketProp.thrustma = RProp{2}(i); %[rad] Thrust misalignmenet angle
         
         % --Chute Properties--
         case 'chutedrag'
@@ -129,6 +152,10 @@ for i=1:m
             simuProp.recoveryRes = RProp{2}(i); % Resolution for recovery section
         case 'count'
             simuProp.count = RProp{2}(i); % Number of simulations to run
+        case 'sigma_G'
+            simuProp.sigma_G = RProp{2}(i); % [m/s]Standard deviation in gust velocity (need wind data at launch date)
+        case 'l_G'
+            simuProp.l_G = RProp{2}(i); % [m] Longitudinal turbulence scale length (using assumed value from http://arc.aiaa.org/doi/pdf/10.2514/1.A32037)
     end
 end
 %
@@ -181,8 +208,17 @@ traj = cell(1, simuProp.count);
 %
 % Calculate the characteristic trajectory with no FPA
 %
+%rocketProp.burnoutVelocity = 1000; %[m/s] hardcoded dummy variable
+%rocketProp.burnoutAltitude = 13500; %[m] hardcoded dummy variable
+%simuProp.burnoutAmbientTemp = 216.7; %[K] hardcoded dummy variable
+%simuProp.burnoutAmbientDensity = .247205; %[kg/m^3] hardcoded dummy variable
 fprintf('\nCalculating Characteristic Trajectory\n');
 traj{1} = RocketTrajectory( zerosv, false );
+rocketProp.burnoutVelocity = simuProp.burnOut(6); %[m/s] calculated from RocketTrajectory
+rocketProp.burnoutAltitude = simuProp.burnOut(3); %[m] calculated from RocketTrajectory
+simuProp.burnoutAmbientTemp = interp1(simuProp.tempr, simuProp.temp, rocketProp.burnoutAltitude); %[deg C] calculated using standard altitude values
+simuProp.burnoutAmbientTemp = simuProp.burnoutAmbientTemp + 273.15; %convert from deg C to K
+simuProp.burnoutAmbientDensity = interp1(simuProp.rhor, simuProp.rho, rocketProp.burnoutAltitude); %[kg/m^3] calculated based on altitude
 %
 % Calculate all other trajectories
 %

--- a/dispersion/RocketProperties.txt
+++ b/dispersion/RocketProperties.txt
@@ -13,12 +13,24 @@ wetmass	= 41.69		% [kg] mass of structure+payload+propellant
 drymass = 32.523	% [kg] mass of structure+payload only
 radius	= 0.0762		% [m]radius of body
 static  = 1				% static margin (CG-CP/diameter)
+numfins = 4 %number of rocket fins
+rootchord = .457 %[m] fin root chord
+tipchord = .0508 %[m] fin tip chord
+finheight = .152 %[m] fin height
+C_G = 2.27 %[m] Center of mass (from OpenRocket)
+C_P = 2.41 %[m]Center of pressure (From OpenRocket)
+rocketlength = 3.2 %[m] Rocket length
+launcherlength = 4.8768 %[m] Launcher length
+meanCantAngle = 0.00872665 %[rad] mean fin cant, designed for 0, but worse case scenario of .5 degrees
+liftCoefficientSlope = 1.35 %Lift coefficient slope http://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19930087519.pdf
+
 
 % Rocket Motor Properties
 thrust 	= 8124			% [N] thrust
 Isp		= 210			% [s] specific impulse
 Itot	= 36487			% [N-s] total impulse
 %burn	= 9.18				% [s] Override the burn time, ignoring Isp and thrust. Delete line for no override
+thrustma = .0010908308 %thrust misalignment angle [radians] (from http://www.rsandt.com/media/Standardized%20Perturbation%20Values.pdf value for similar rocket)
 
 % Chute Properties
 chutedrag           = 0.4
@@ -32,3 +44,5 @@ recoveryres = 10    % Recovery resolution.
 rho		= 1.2			% [kg/m^3] Air density for simple simulation
 drag	= 0.5			% Drag coefficient for simple simulation
 gravity	= 9.81			% [m/s^2] Gravitation acceleration at sea level, for simple sim
+sigma_G = 2.2352        % [m/s]Standard deviation in gust velocity (need wind data at launch date)
+l_G = 300               % [m] Longitudinal turbulence scale length (using assumed value from http://arc.aiaa.org/doi/pdf/10.2514/1.A32037)

--- a/dispersion/RocketTrajectory.m
+++ b/dispersion/RocketTrajectory.m
@@ -24,24 +24,25 @@ global simuProp;
 %
 % Calculate flight path angle vector vertical
 %
-gamma = GetSTDFPA();
-FPAv = normrnd(0, gamma);
-max(min(FPAv, pi/2),-pi/2);
-%
-% General FPA lateral
-%
-FPAl = 2*pi*rand();
-%
-% Convert to cartesian coords
-%
-x = cos(FPAl)*sin(FPAv);
-y = sin(FPAl)*sin(FPAv);
-z = cos(FPAv);
-FPA = [x,y,z];
+if useFPA
+    gamma = GetSTDFPA();
+    FPAv = normrnd(0, gamma);
+    max(min(FPAv, pi/2),-pi/2);
+    %
+    % General FPA lateral
+    %
+    FPAl = 2*pi*rand();
+    %
+    % Convert to cartesian coords
+    %
+    x = cos(FPAl)*sin(FPAv);
+    y = sin(FPAl)*sin(FPAv);
+    z = cos(FPAv);
+    FPA = [x,y,z];
 %
 % Reset to vertical if not using FPA
 %
-if ~useFPA
+else
     FPA = [0,0,1];
 end
 %
@@ -50,6 +51,7 @@ end
 fprintf('Calculating boost phase...');
 tstamp = cputime;
 boostm = IntegrateStepFunction( @RK45Wind, @BoostStepTerminate, sv, @BoostAccel, FPA );
+simuProp.burnOut = boostm(end,:); 
 fprintf('done! Took %0.3fs\n', cputime-tstamp);
 %
 % Simulate the coast phase


### PR DESCRIPTION
Updates the FPA calculations to use the results of the characteristic
trajectory and rocket/simulation properties, rather than hard-coded
values.
Closes #8
